### PR TITLE
Shopping tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@ import shutil
 import os
 import pytest
 import sys 
+from flask import session
+from flask_wtf.csrf import generate_csrf
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from northwind import create_app, db
@@ -15,6 +18,7 @@ def app():
 
     app = create_app()
     app.config['DATABASE'] = TEST_DB
+    app.config['WTF_CSRF_ENABLED'] = False  # Disable CSRF protection for testing
 
     with app.app_context():
         db.init_db()
@@ -98,9 +102,9 @@ class CartActions(object):
             db = get_db()
             db.execute("INSERT INTO Cart_Items (CartID, ProductID, Quantity) VALUES (?, ?, ?)", (cart_id, product_id, quantity))
             db.commit()
+     
 
-
-@pytest.fixture
+@pytest.fixture(scope='function')
 def auth(client):
     return AuthActions(client)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,31 @@ class SearchActions(object):
             db.execute("INSERT INTO Product (ProductName, UnitPrice, CategoryId, SupplierId, UnitsInStock, UnitsOnOrder, ReorderLevel, Discontinued) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                        (product_name, unit_price, category_id, supplier_id, 999, 999, 999, discontinued))
             db.commit()
+            return db.execute("SELECT Id FROM Product WHERE ProductName = ?", (product_name,)).fetchone()[0]
+
+
+class CartActions(object):
+    def __init__(self, app):
+        self._app = app
+
+    def insert_shopping_cart(self, user_id = None, session_id = "testtesttesttesttesttesttesttest"):
+        with self._app.app_context():
+            db = get_db()
+            if user_id is not None:
+                db.execute("INSERT INTO Shopping_Cart (UserID, SessionID) VALUES (?, ?)", (user_id, session_id))
+            else:
+                db.execute("INSERT INTO Shopping_Cart (SessionID) VALUES (?)", (session_id,))
+            db.commit()
+            if user_id is not None:
+                return db.execute("SELECT CartID FROM Shopping_Cart WHERE UserID = ?", (user_id,)).fetchone()[0]
+            else:
+                return db.execute("SELECT CartID FROM Shopping_Cart WHERE SessionID = ?", (session_id,)).fetchone()[0]
+
+    def insert_cart_items(self, cart_id, product_id, quantity):
+        with self._app.app_context():
+            db = get_db()
+            db.execute("INSERT INTO Cart_Items (CartID, ProductID, Quantity) VALUES (?, ?, ?)", (cart_id, product_id, quantity))
+            db.commit()
 
 
 @pytest.fixture
@@ -83,3 +108,8 @@ def auth(client):
 @pytest.fixture
 def search(app):
     return SearchActions(app)
+
+
+@pytest.fixture
+def cart(app):
+    return CartActions(app)

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -1,0 +1,127 @@
+from flask import session
+import re
+from northwind.cart import get_cart, get_cart_items, get_units_in_stock, update_quantity
+from northwind.db import get_db
+
+def test_get_session_id(client):
+    with client:
+        client.get('/cart/')
+        assert 'session_id' in session
+        session_id = session['session_id']
+        assert len(session_id) == 32
+
+def test_get_cart_user_id(client, app, auth, cart):
+    with app.app_context():
+        db = get_db()
+        auth.register()
+        auth.login()
+        user_id = "test"
+        cart.insert_shopping_cart(user_id=user_id)
+        with client:
+            client.get('/cart/')
+            cart = get_cart(db, user_id)
+            assert cart is not None
+
+
+def test_get_cart_session_id(client, app, cart):
+    with app.app_context():
+        db = get_db()
+        session_id = "testtesttesttesttesttesttesttest"
+        cart.insert_shopping_cart(session_id=session_id)
+        with client:
+            client.get('/cart/')
+            cart = get_cart(db, session_id)
+            assert cart is not None        
+        
+
+def test_get_cart_items(app, search, cart):
+    with app.app_context():
+        db = get_db()
+        supplier_id = search.insert_supplier()
+        category_id = search.insert_category()
+        product_id = search.insert_product(supplier_id=supplier_id, category_id=category_id)
+        cart_id = cart.insert_shopping_cart()
+        cart.insert_cart_items(cart_id, product_id, 2)
+
+        cart = {'CartID': cart_id}
+        cart_items = get_cart_items(db, cart)
+        assert len(cart_items) == 1
+        assert cart_items[0]['ProductName'] == 'TestProduct'
+        assert cart_items[0]['Quantity'] == 2
+
+def test_get_units_in_stock(app, search, cart):
+    with app.app_context():
+        db = get_db()
+        supplier_id = search.insert_supplier()
+        category_id = search.insert_category()
+        product_id = search.insert_product(supplier_id=supplier_id, category_id=category_id)
+        cart_id = cart.insert_shopping_cart()
+        cart.insert_cart_items(cart_id, product_id, 2)
+
+        units_in_stock = get_units_in_stock(db, cart_id)
+        assert units_in_stock['UnitsInStock'] == 999
+
+def test_view_cart(client, app, search, cart):
+    with app.app_context():
+        session_id = "testtesttesttesttesttesttesttest"
+        supplier_id = search.insert_supplier()
+        category_id = search.insert_category()
+        product_id = search.insert_product(supplier_id=supplier_id, category_id=category_id)
+        cart_id = cart.insert_shopping_cart()
+        cart.insert_cart_items(cart_id, product_id, 2)
+        with client:
+            with client.session_transaction() as sess:
+                sess['session_id'] = session_id
+            response = client.get('/cart/')
+            assert response.status_code == 200
+            response_text = response.data.decode('utf-8')
+            assert not re.search(r'Shopping Cart is empty.', response_text)
+
+
+def test_update_quantity(client, app, search, cart):
+    with app.app_context():
+        db = get_db()
+        session_id = "testtesttesttesttesttesttesttest"
+        supplier_id = search.insert_supplier()
+        category_id = search.insert_category()
+        product_id = search.insert_product(supplier_id=supplier_id, category_id=category_id)
+        cart_id = cart.insert_shopping_cart()
+        cart.insert_cart_items(cart_id, product_id, 2)
+        cart_item_id = db.execute("SELECT CartItemID FROM Cart_Items WHERE CartID = ? AND ProductID = ?", (cart_id, product_id)).fetchone()[0]
+        with client:
+            with client.session_transaction() as sess:
+                sess['session_id'] = session_id
+            response = client.post('/cart/update-quantity', data={
+                'item_id': cart_item_id,
+                'quantity': 2,
+                'increment': '+'
+                })
+            assert response.status_code == 302  # Redirect to view_cart
+            
+            # Access flashed messages from the session
+            with client.session_transaction() as sess:
+                flashed_messages = sess.get('_flashes', [])
+                assert "Error updating item quantity." not in [msg for category, msg in flashed_messages]
+
+            with app.app_context():
+                updated_quantity = db.execute("SELECT Quantity FROM Cart_Items WHERE CartItemID = ?", (cart_item_id,)).fetchone()[0]
+                assert updated_quantity == 3
+
+                
+def test_remove_item(client, app, search, cart):
+    with app.app_context():
+        db = get_db()
+        session_id = "testtesttesttesttesttesttesttest"
+        supplier_id = search.insert_supplier()
+        category_id = search.insert_category()
+        product_id = search.insert_product(supplier_id=supplier_id, category_id=category_id)
+        cart_id = cart.insert_shopping_cart()
+        cart.insert_cart_items(cart_id, product_id, 2)
+        cart_item_id = db.execute("SELECT CartItemID FROM Cart_Items WHERE CartID = ? AND ProductID = ?", (cart_id, product_id)).fetchone()[0]
+        with client:
+            with client.session_transaction() as sess:
+                sess['session_id'] = session_id
+            response = client.post('/cart/remove-item', data={'item_id': cart_item_id, 'remove': True})
+            assert response.status_code == 302  # Redirect to view_cart
+            cart_items = db.execute("SELECT * FROM Cart_Items WHERE CartItemID = ?", (cart_item_id,)).fetchall()
+            assert len(cart_items) == 0

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -47,3 +47,19 @@ def test_init_db(runner, db_connection):
     """)
     index = cursor.fetchone()
     assert index is not None, "Index 'idx_product_name' was not created"
+
+    # Check if the Shopping_Cart table exists
+    cursor.execute("""
+        SELECT name FROM sqlite_master 
+        WHERE type='table' AND name='Shopping_Cart';
+    """)
+    table = cursor.fetchone()
+    assert table is not None, "Shopping_Cart table was not created"
+
+    # Check if the Cart_Items table exists
+    cursor.execute("""
+        SELECT name FROM sqlite_master 
+        WHERE type='table' AND name='Cart_Items';
+    """)
+    table = cursor.fetchone()
+    assert table is not None, "Cart_Items table was not created"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -12,6 +12,8 @@ def test_search_product(client, search):
     search.insert_product(supplier_id=supplier_id)
 
     response = client.post('/', data={'search': 'TestProduct'})
+    assert response.status_code == 302
+    response = client.get(response.headers['Location'])
     assert response.status_code == 200
     response_text = response.data.decode('utf-8')
     assert 'TestProduct' in response_text
@@ -24,6 +26,8 @@ def test_search_partial_matches(client, search):
     search.insert_product(product_name="AmazingTest", supplier_id=supplier_id)
     
     response = client.post('/', data={'search': 'Test'})
+    assert response.status_code == 302
+    response = client.get(response.headers['Location'])
     assert response.status_code == 200
     response_text = response.data.decode('utf-8')
     assert 'AmazingTestProduct' in response_text, "Partial match not allowed"
@@ -37,6 +41,8 @@ def test_search_category(client, search):
     search.insert_product(supplier_id=supplier_id, category_id=category_id)
 
     response = client.post('/', data={'search': 'TestCategory'})
+    assert response.status_code == 302
+    response = client.get(response.headers['Location'])
     assert response.status_code == 200
     response_text = response.data.decode('utf-8')
     assert 'TestProduct' in response_text
@@ -45,6 +51,8 @@ def test_search_category(client, search):
 
 def test_search_no_results(client):
     response = client.post('/', data={'search': 'NonExistent'})
+    assert response.status_code == 302
+    response = client.get(response.headers['Location'])
     assert response.status_code == 200
     response_text = response.data.decode('utf-8')
     assert 'Product not found' in response_text


### PR DESCRIPTION
I added the tests for the cart functionality. It took me a while to figure out why the forms weren't validating, but it stemmed from a mismatch of csrf_tokens coming from the hidden field in the form. As we are not worried about bot attacks in testing, I disabled the reqirement of csrf_tokens in the testing environment.

In the future when we have a config file with a secret key I may be able to reinstate the token generation.

Additionally, I fixed the tests that broke in the search merge.